### PR TITLE
adding new PH4H domain for Prod

### DIFF
--- a/scripts/tests/folder_mandatory_files.py
+++ b/scripts/tests/folder_mandatory_files.py
@@ -9,7 +9,7 @@ def test_folder_mandatory_files(country_folder):
 
     # Testing folder structure
     for domain in ofiles.keys():
-        assert domain in ('DCC','DDCC','DIVOC','ICAO','SHC','IPS-PILGRIMAGE'), 'Invalid domain: '+domain
+        assert domain in ('DCC','DDCC','DIVOC','ICAO','SHC','IPS-PILGRIMAGE','PH4H'), 'Invalid domain: '+domain
 
         assert ('TLS', 'TLS.pem') in ofiles[domain], f'TLS cert is missing in domain {domain}'
         assert ('TLS', 'CA.pem') in ofiles[domain], f'TLS/CA cert is missing in domain {domain}'

--- a/scripts/tests/groups_domains.py
+++ b/scripts/tests/groups_domains.py
@@ -10,4 +10,4 @@ def test_valid_domain(cert):
 
     domain = cert.pathinfo.get('domain')
     assert domain, 'Certificate at incorrect location'
-    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','IPS-PILGRIMAGE'), 'Invalid domain: ' + domain
+    assert domain.upper() in ('DCC','DDCC','DIVOC','ICAO','SHC','IPS-PILGRIMAGE','PH4H'), 'Invalid domain: ' + domain


### PR DESCRIPTION
H4H = Panamerican Health .... 
This shall succeed the DDVC-Racsel domain

 check how domains may get deprectated in the future

AC

smart trust network gateway accepted PH4H as new supported domain
participant onboarding repository supports new domain
template repository outlines PH4H as supported domain